### PR TITLE
use an ordered dict to store links inside visualizer

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -8,3 +8,4 @@ Meshing 0.0.3
 Rotations 0.2.0
 CoordinateTransformations 0.2.0
 StaticArrays 0.0.4
+DataStructures 0.4

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -130,7 +130,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "adding: /Users/rdeits/.julia/v0.5/DrakeVisualizer/src/lcmtypes to the python path\n"
+      "adding: /Users/rdeits/locomotion/explorations/point-cloud-signed-distance/packages/v0.5/DrakeVisualizer/src/lcmtypes to the python path\n"
      ]
     }
    ],
@@ -146,25 +146,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Process(`drake-visualizer`, ProcessRunning)"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Run the following command to launch the viewer application:\n",
-    "proc = DrakeVisualizer.new_window()"
+    "# proc = DrakeVisualizer.new_window()"
    ]
   },
   {
@@ -234,39 +223,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "DrakeVisualizer.Robot(DrakeVisualizer.Link[DrakeVisualizer.Link(DrakeVisualizer.GeometryData[DrakeVisualizer.GeometryData{CoordinateTransformations.IdentityTransformation,GeometryTypes.HyperRectangle{3,Float64}}(GeometryTypes.HyperRectangle{3,Float64}(Vec(0.0,0.0,0.0),Vec(1.0,1.0,1.0)),CoordinateTransformations.IdentityTransformation(),RGBA{Float64}(1.0,0.0,0.0,0.5))],\"link\")])"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Let's look more at what's being done under the hood. The model\n",
-    "# owns a reference to a Robot object. A Robot contains a list of \n",
-    "# Link objects. Each Link contains a list of GeometryData objects.\n",
-    "# And each GeometryData contains a single geometric primitive as\n",
-    "# well as information about its color and its position with\n",
-    "# respect to the link that contains it.\n",
-    "#\n",
-    "# Calling Visualizer() on a single geometry (the box above) results in \n",
-    "# a new Robot being automatically created. That Robot has one link,\n",
-    "# and that Link has one GeometryData whose geometry is the box we\n",
-    "# provided. \n",
-    "model.robot"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 8,
    "metadata": {
     "collapsed": false
@@ -275,8 +231,8 @@
     {
      "data": {
       "text/plain": [
-       "1-element Array{DrakeVisualizer.Link,1}:\n",
-       " DrakeVisualizer.Link(DrakeVisualizer.GeometryData[DrakeVisualizer.GeometryData{CoordinateTransformations.IdentityTransformation,GeometryTypes.HyperRectangle{3,Float64}}(GeometryTypes.HyperRectangle{3,Float64}(Vec(0.0,0.0,0.0),Vec(1.0,1.0,1.0)),CoordinateTransformations.IdentityTransformation(),RGBA{Float64}(1.0,0.0,0.0,0.5))],\"link\")"
+       "DataStructures.OrderedDict{Int64,Array{DrakeVisualizer.GeometryData,1}} with 1 entry:\n",
+       "  1 => DrakeVisualizer.GeometryData[DrakeVisualizer.GeometryData{CoordinateTran…"
       ]
      },
      "execution_count": 8,
@@ -285,7 +241,18 @@
     }
    ],
    "source": [
-    "model.robot.links"
+    "# Let's look more at what's being done under the hood. The model\n",
+    "# contains an ordered dictionary from keys to Link objects. Each \n",
+    "# Link is a list of GeometryData objects.\n",
+    "# And each GeometryData contains a single geometric primitive as\n",
+    "# well as information about its color and its position with\n",
+    "# respect to the link that contains it.\n",
+    "#\n",
+    "# Calling Visualizer() on a single geometry (the box above) results in \n",
+    "# a new Robot being automatically created. That Robot has one link,\n",
+    "# and that Link has one GeometryData whose geometry is the box we\n",
+    "# provided.\n",
+    "model.links"
    ]
   },
   {
@@ -298,7 +265,8 @@
     {
      "data": {
       "text/plain": [
-       "GeometryTypes.HyperRectangle{3,Float64}(Vec(0.0,0.0,0.0),Vec(1.0,1.0,1.0))"
+       "1-element Array{DrakeVisualizer.GeometryData,1}:\n",
+       " DrakeVisualizer.GeometryData{CoordinateTransformations.IdentityTransformation,GeometryTypes.HyperRectangle{3,Float64}}(GeometryTypes.HyperRectangle{3,Float64}(Vec(0.0,0.0,0.0),Vec(1.0,1.0,1.0)),CoordinateTransformations.IdentityTransformation(),RGBA{Float64}(1.0,0.0,0.0,0.5))"
       ]
      },
      "execution_count": 9,
@@ -307,9 +275,9 @@
     }
    ],
    "source": [
-    "# Here's the box we created. It's now the first (and only) geometry\n",
-    "# of the first (and only) link of the robot:\n",
-    "model.robot.links[1].geometry_data[1].geometry"
+    "# Here's that single link. Since we didn't provide a key for our \n",
+    "# geometry, it was automatically given the key 1:\n",
+    "model.links[1]"
    ]
   },
   {
@@ -318,14 +286,38 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DrakeVisualizer.GeometryData{CoordinateTransformations.IdentityTransformation,GeometryTypes.HyperRectangle{3,Float64}}(GeometryTypes.HyperRectangle{3,Float64}(Vec(0.0,0.0,0.0),Vec(1.0,1.0,1.0)),CoordinateTransformations.IdentityTransformation(),RGBA{Float64}(1.0,0.0,0.0,0.5))"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "@assert model.robot.links[1].geometry_data[1].geometry === box"
+    "# Here's the box we created. It's the first (and only) geometry\n",
+    "# of the first (and only) link of the robot. \n",
+    "model.links[1][1]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "@assert model.links[1][1].geometry === box"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
    "metadata": {
     "collapsed": false
    },
@@ -340,7 +332,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {
     "collapsed": false
    },
@@ -351,13 +343,13 @@
     "\n",
     "# We can create a new Link that contains two geometries: the \n",
     "# green box and the blue box. \n",
-    "link1 = Link([green_box_data; blue_box_data], \"link1\")\n",
+    "link1 = Link([green_box_data; blue_box_data])\n",
     "model = Visualizer(link1);"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {
     "collapsed": false
    },
@@ -372,7 +364,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {
     "collapsed": false
    },
@@ -382,17 +374,16 @@
     "# they need to be on separate links. Let's create a second\n",
     "# Link and then a robot containing both of those links. \n",
     "red_box_data = GeometryData(box)\n",
-    "link2 = Link([red_box_data], \"link2\")\n",
-    "robot = Robot([link1; link2])\n",
+    "link2 = Link([red_box_data])\n",
     "\n",
     "# When we load this new robot, the two links are both drawn \n",
     "# at position [0; 0; 0]; right on top of each other.\n",
-    "model = Visualizer(robot);\n"
+    "model = Visualizer([link1, link2]);"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 23,
    "metadata": {
     "collapsed": false
    },
@@ -406,7 +397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 24,
    "metadata": {
     "collapsed": false
    },
@@ -437,9 +428,9 @@
        "nothing"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 24,
      "metadata": {
-      "comm_id": "a497fd1c-6765-47d6-a9a1-fe558eeb1977",
+      "comm_id": "9bc9c7a7-6452-4f8b-be6c-ba6e14f5a1d0",
       "reactive": true
      },
      "output_type": "execute_result"
@@ -454,11 +445,63 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 25,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
+   "source": [
+    "# Remembering the order of the links is likely to get confusing\n",
+    "# as our robots get more complicated. Instead, we can give each\n",
+    "# link a name (or any other identifying key) and then use a \n",
+    "# dictionary to specify the pose of each link:\n",
+    "\n",
+    "model = Visualizer(Dict(:red => red_box_data, :bluegreen => link1));"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Now we can set the positions of the links by passing a Dict to \n",
+    "# draw():\n",
+    "\n",
+    "draw(model, Dict(:red => IdentityTransformation(), \n",
+    "                 :bluegreen => Translation(0., 0, 2.0)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# We don't have to draw all of the links ever time. Let's just move\n",
+    "# the red box:\n",
+    "draw(model, Dict(:red => Translation(1., 0, 0)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: imported binding for cat overwritten in module Main\n"
+     ]
+    }
+   ],
    "source": [
     "# Of course, we can draw much more interesting geometries than \n",
     "# just simple boxes. Let's load a 3D mesh and visualize it:\n",
@@ -471,7 +514,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 29,
    "metadata": {
     "collapsed": false
    },
@@ -479,12 +522,12 @@
     {
      "data": {
       "text/plain": [
-       "DrakeVisualizer.Visualizer(DrakeVisualizer.Robot(DrakeVisualizer.Link[DrakeVisualizer.Link(DrakeVisualizer.GeometryData[DrakeVisualizer.GeometryData{CoordinateTransformations.IdentityTransformation,GeometryTypes.HomogenousMesh{FixedSizeArrays.Point{3,Float64},GeometryTypes.Face{3,Int64,0},Void,Void,Void,Void,Void}}(HomogenousMesh(\n",
+       "DrakeVisualizer.Visualizer{Int64}(DataStructures.OrderedDict(1=>DrakeVisualizer.GeometryData[DrakeVisualizer.GeometryData{CoordinateTransformations.IdentityTransformation,GeometryTypes.HomogenousMesh{FixedSizeArrays.Point{3,Float64},GeometryTypes.Face{3,Int64,0},Void,Void,Void,Void,Void}}(HomogenousMesh(\n",
        "    vertices: 6945xFixedSizeArrays.Point{3,Float64},     faces: 13260xGeometryTypes.Face{3,Int64,0}, )\n",
-       ",CoordinateTransformations.IdentityTransformation(),RGBA{Float64}(1.0,0.0,0.0,0.5))],\"link\")]),1,PyLCM.LCM(PyObject <LCM object at 0x321da5570>))"
+       ",CoordinateTransformations.IdentityTransformation(),RGBA{Float64}(1.0,0.0,0.0,0.5))]),1,PyLCM.LCM(PyObject <LCM object at 0x3174596c0>))"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -514,7 +557,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 31,
    "metadata": {
     "collapsed": false
    },
@@ -523,7 +566,7 @@
      "data": {
       "text/html": [],
       "text/plain": [
-       "Interact.Slider{Float64}(Signal{Float64}(-0.02040816326530612, nactions=0),\"iso_level\",-0.02040816326530612,linspace(-1.0,1.0,50),\".3f\",true)"
+       "Interact.Slider{Float64}(Signal{Float64}(0.0, nactions=0),\"iso_level\",0.0,linspace(-1.0,1.0,51),\".3f\",true)"
       ]
      },
      "metadata": {},
@@ -532,14 +575,14 @@
     {
      "data": {
       "text/plain": [
-       "DrakeVisualizer.Visualizer(DrakeVisualizer.Robot(DrakeVisualizer.Link[DrakeVisualizer.Link(DrakeVisualizer.GeometryData[DrakeVisualizer.GeometryData{CoordinateTransformations.IdentityTransformation,GeometryTypes.HomogenousMesh{FixedSizeArrays.Point{3,Float64},GeometryTypes.Face{3,Int64,0},Void,Void,Void,Void,Void}}(HomogenousMesh(\n",
-       "    vertices: 6915xFixedSizeArrays.Point{3,Float64},     faces: 13212xGeometryTypes.Face{3,Int64,0}, )\n",
-       ",CoordinateTransformations.IdentityTransformation(),RGBA{Float64}(1.0,0.0,0.0,0.5))],\"link\")]),1,PyLCM.LCM(PyObject <LCM object at 0x3229335d0>))"
+       "DrakeVisualizer.Visualizer{Int64}(DataStructures.OrderedDict(1=>DrakeVisualizer.GeometryData[DrakeVisualizer.GeometryData{CoordinateTransformations.IdentityTransformation,GeometryTypes.HomogenousMesh{FixedSizeArrays.Point{3,Float64},GeometryTypes.Face{3,Int64,0},Void,Void,Void,Void,Void}}(HomogenousMesh(\n",
+       "    vertices: 6945xFixedSizeArrays.Point{3,Float64},     faces: 13260xGeometryTypes.Face{3,Int64,0}, )\n",
+       ",CoordinateTransformations.IdentityTransformation(),RGBA{Float64}(1.0,0.0,0.0,0.5))]),1,PyLCM.LCM(PyObject <LCM object at 0x3174598a0>))"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 31,
      "metadata": {
-      "comm_id": "f5d726d2-aa82-4b68-aed7-4e2da1ccf97f",
+      "comm_id": "289caec4-7ef3-4300-b631-b1f8055f0528",
       "reactive": true
      },
      "output_type": "execute_result"
@@ -555,7 +598,7 @@
     "lower_bound = Vec(-1.,-1,-1)\n",
     "upper_bound = Vec(1., 1, 1)\n",
     "\n",
-    "@manipulate for iso_level in linspace(-1, 1)\n",
+    "@manipulate for iso_level in linspace(-1, 1, 51)\n",
     "    geometry = contour_mesh(f, lower_bound, upper_bound, iso_level)\n",
     "    model = Visualizer(geometry);\n",
     "end\n",
@@ -566,7 +609,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 32,
    "metadata": {
     "collapsed": false
    },
@@ -583,7 +626,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 33,
    "metadata": {
     "collapsed": false
    },
@@ -604,9 +647,9 @@
        "nothing"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 33,
      "metadata": {
-      "comm_id": "1621e259-cf6f-47c7-97af-32e64f6e3f5e",
+      "comm_id": "80be76fa-bbbb-44cf-8384-0d8ea3c7466b",
       "reactive": true
      },
      "output_type": "execute_result"
@@ -622,7 +665,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 34,
    "metadata": {
     "collapsed": false
    },
@@ -643,9 +686,9 @@
        "nothing"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 34,
      "metadata": {
-      "comm_id": "b4d41922-649e-4886-9d07-acaf127b5b4c",
+      "comm_id": "4e683c8f-f3b9-4edf-8f3b-91dec9685490",
       "reactive": true
      },
      "output_type": "execute_result"
@@ -677,8 +720,8 @@
     }
    ],
    "source": [
-    "# Close the viewer\n",
-    "kill(proc)"
+    "# Close the viewer:\n",
+    "# kill(proc)"
    ]
   }
  ],
@@ -696,45 +739,45 @@
   },
   "widgets": {
    "state": {
-    "39004ced-07df-4447-9695-5cb9d75e90e2": {
-     "views": [
-      {
-       "cell_index": 21
-      }
-     ]
-    },
-    "3debe61b-9f85-4021-a8d7-08b7b16d20a9": {
+    "113f5a4a-38cd-4770-a3dd-2f277f8449f6": {
      "views": [
       {
        "cell_index": 16
       }
      ]
     },
-    "9f0e1d87-0d32-4cd1-923f-5fc96a07854c": {
+    "12c6e479-87d5-4126-a117-d3c4d86e53da": {
      "views": [
       {
        "cell_index": 16
       }
      ]
     },
-    "afe7c004-f5e9-4668-9255-8caa982fadf8": {
-     "views": [
-      {
-       "cell_index": 19
-      }
-     ]
-    },
-    "d0f3b731-10bf-49be-a1d5-4dd6aa101b4c": {
-     "views": [
-      {
-       "cell_index": 16
-      }
-     ]
-    },
-    "f4eba759-f456-4700-97b9-3853072046b1": {
+    "3607e992-d999-4b56-8ab8-ebd6aa5fed73": {
      "views": [
       {
        "cell_index": 22
+      }
+     ]
+    },
+    "935fbdec-0c0e-47eb-a80a-721c0bea52fd": {
+     "views": [
+      {
+       "cell_index": 16
+      }
+     ]
+    },
+    "9d9ba1a3-79b1-418f-a03a-9bdba3f95b6c": {
+     "views": [
+      {
+       "cell_index": 24
+      }
+     ]
+    },
+    "b95bd01c-cb2b-44d1-b586-ca82f6d7f901": {
+     "views": [
+      {
+       "cell_index": 25
       }
      ]
     }

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,8 +13,7 @@ try
         f = x -> norm(x)^2
         bounds = HyperRectangle(Vec(0.,0,0), Vec(1.,1,1))
         geom = contour_mesh(f, minimum(bounds), maximum(bounds))
-        robot = convert(Robot, geom)
-        vis = Visualizer(robot, 1)
+        vis = Visualizer(geom, 1)
     end
 
     @testset "link_list_load" begin
@@ -42,7 +41,7 @@ try
         for (i, l) in enumerate(link_lengths)
             geometry = HyperRectangle(Vec(0., -0.1, -0.1), Vec(l, 0.2, 0.2))
             geometry_data = GeometryData(geometry)
-            push!(links, Link([geometry_data], "link$(i)"))
+            push!(links, Link([geometry_data]))
         end
 
 
@@ -58,8 +57,7 @@ try
             transforms
         end
 
-        robot = Robot(links)
-        model = Visualizer(robot)
+        model = Visualizer(links)
 
         for x in product([linspace(-pi, pi, 11) for i in 1:length(link_lengths)]...)
             origins = link_origins(reverse(x))
@@ -84,6 +82,14 @@ try
         for vis in [vis1, vis2]
             draw(vis, [IdentityTransformation()])
         end
+    end
+
+    @testset "link dictionaries" begin
+        links = Dict("cylinder" => Link(HyperCylinder{3, Float64}(1.0, 0.5)),
+                     "rectangle" => HyperRectangle(Vec(0., -0.1, -0.1), Vec(1, 0.2, 0.2)))
+        vis = Visualizer(links)
+        draw(vis, Dict("cylinder" => IdentityTransformation()))
+        draw(vis, Dict("rectangle" => Translation(1., 2, -1)))
     end
 
     @testset "demo_notebook" begin


### PR DESCRIPTION
Robot is now just an alias for an ordered dict from a key type to Link,
and Link is just an alias for a vector of GeometryData. The key in the
ordered dict serves as the link name, which makes issues with duplicate
names less likely (and more obvious when they occur). Also, it is now
possible to pass draw() a dict from keys to transforms, which frees us
from having to remember the link order and also allows partial draws by
only sending transforms for some links.