### PR TITLE
remove unused parent attribute from lazytree

### DIFF
--- a/src/lazytree.jl
+++ b/src/lazytree.jl
@@ -9,10 +9,9 @@ using StaticArrays: SMatrix, SVector
 type LazyTree{K, T}
     data::T
     children::Dict{K, LazyTree{K, T}}
-    parent::Nullable{LazyTree{K, T}}
 
-    LazyTree() = new(T(), Dict{K, LazyTree{K, T}}(), Nullable{LazyTree{K, T}}())
-    LazyTree(data::T) = new(data, Dict{K, LazyTree{K, T}}(), Nullable{LazyTree{K, T}}())
+    LazyTree() = new(T(), Dict{K, LazyTree{K, T}}())
+    LazyTree(data::T) = new(data, Dict{K, LazyTree{K, T}}())
 end
 
 function show(io::IO, t::LazyTree)
@@ -24,11 +23,9 @@ end
 
 children(t::LazyTree) = t.children
 data(t::LazyTree) = t.data
-parent(t::LazyTree) = get(t.parent)
 
 function setindex!{T <: LazyTree}(t::T, child::T, childname)
     t.children[childname] = child
-    child.parent = t
 end
 setindex!{K, T}(t::LazyTree{K, T}, childdata::T, childname::K) =
     setindex!(t, LazyTree{K, T}(childdata), childname)

--- a/test/lazytree.jl
+++ b/test/lazytree.jl
@@ -3,12 +3,10 @@ using DrakeVisualizer.LazyTrees: LazyTree, children, data, delete!, descendants
 @testset "LazyTrees" begin
     @testset "constructors" begin
         t = LazyTree{Symbol, Vector{Int}}()
-        @test isnull(t.parent)
         @test isempty(children(t))
         show(IOBuffer(), t)
 
         t2 = LazyTree{Symbol, Vector{Int}}(Int[])
-        @test isnull(t2.parent)
         @test isempty(children(t))
         show(IOBuffer(), t2)
     end


### PR DESCRIPTION
This was probably used at some point in development, but it's not useful anymore. 