### PR TITLE
Fix custom geometry bugs and disable listener thread for now

### DIFF
--- a/src/geometry_types.jl
+++ b/src/geometry_types.jl
@@ -8,7 +8,7 @@ origin{N, T}(geometry::HyperEllipsoid{N, T}) = geometry.center
 radii{N, T}(geometry::HyperEllipsoid{N, T}) = geometry.radii
 center(geometry::HyperEllipsoid) = origin(geometry)
 
-type HyperCylinder{N, T} <: GeometryTypes.GeometryPrimitive{N, T}
+type HyperCylinder{N, T} <: GeometryPrimitive{N, T}
     length::T # along last axis
     radius::T
     # origin is at center

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -54,7 +54,11 @@ end
 intrinsic_transform(g) = IdentityTransformation()
 intrinsic_transform(g::Nullable) = isnull(g) ? IdentityTransformation() : intrinsic_transform(get(g))
 intrinsic_transform(geomdata::GeometryData) = intrinsic_transform(geomdata.geometry)
-intrinsic_transform(g::GeometryPrimitive) = Translation(center(g)...)
+intrinsic_transform(g::HyperRectangle) = Translation(center(g)...)
+intrinsic_transform(g::HyperSphere) = Translation(center(g)...)
+intrinsic_transform(g::HyperEllipsoid) = Translation(center(g)...)
+intrinsic_transform(g::HyperCylinder) = Translation(center(g)...)
+intrinsic_transform(g::HyperCube) = Translation(center(g)...)
 
 serialize(color::Colorant) = (red(color),
                               green(color),

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -51,12 +51,10 @@ function serialize(geomdata::GeometryData)
     params
 end
 
-intrinsic_transform(geom::Nullable) = isnull(geom) ? IdentityTransformation() : intrinsic_transform(get(geom))
+intrinsic_transform(g) = IdentityTransformation()
+intrinsic_transform(g::Nullable) = isnull(g) ? IdentityTransformation() : intrinsic_transform(get(g))
 intrinsic_transform(geomdata::GeometryData) = intrinsic_transform(geomdata.geometry)
-intrinsic_transform(geom::AbstractMesh) = IdentityTransformation()
-intrinsic_transform(geom::AbstractGeometry) = Translation(center(geom)...)
-intrinsic_transform(geom::PointCloud) = IdentityTransformation()
-intrinsic_transform(triad::Triad) = IdentityTransformation()
+intrinsic_transform(g::GeometryPrimitive) = Translation(center(g)...)
 
 serialize(color::Colorant) = (red(color),
                               green(color),

--- a/src/visualizer.jl
+++ b/src/visualizer.jl
@@ -59,9 +59,6 @@ An error ocurred while handling the viewer response:
             end
         end
         subscribe(lcm, "DIRECTOR_TREE_VIEWER_RESPONSE", handle_msg, Comms.CommsT)
-        @async while true
-            handle(lcm)
-        end
         vis
     end
 end
@@ -106,6 +103,7 @@ function publish!(vis::CoreVisualizer)
         data = serialize(vis, vis.queue)
         msg = to_lcm(data)
         publish(vis.lcm, "DIRECTOR_TREE_VIEWER_REQUEST", msg)
+        empty!(vis.queue)
     end
 end
 
@@ -176,8 +174,8 @@ end
 
 # Old-style visualizer interface
 function Visualizer(geom::GeometryData)
-    vis = Visualizer()
-    setgeometry!(vis[:body1], geom)
+    vis = Visualizer()[:body1]
+    setgeometry!(vis, geom)
     vis
 end
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,4 +1,6 @@
-Iterators
-IJulia
-Interact
-MeshIO
+Iterators 0.2
+IJulia 1.4.1
+Interact 0.4
+MeshIO 0.0.6
+Polyhedra 0.1.3
+CDDLib 0.1.2

--- a/test/polyhedra.jl
+++ b/test/polyhedra.jl
@@ -1,0 +1,12 @@
+
+@testset "Polyhedra" begin
+    ext1 = SimpleVRepresentation([0 1 2 3;0 2 1 3; 1 0 2 3; 1 2 0 3; 2 0 1 3; 2 1 0 3;
+                                  0 1 3 2;0 3 1 2; 1 0 3 2; 1 3 0 2; 3 0 1 2; 3 1 0 2;
+                                  0 3 2 1;0 2 3 1; 3 0 2 1; 3 2 0 1; 2 0 3 1; 2 3 0 1;
+                                  3 1 2 0;3 2 1 0; 1 3 2 0; 1 2 3 0; 2 3 1 0; 2 1 3 0])
+    poly1 = CDDPolyhedron{4,Rational{BigInt}}(ext1)
+
+    poly2 = project(poly1, [1 1 1; -1 1 1; 0 -2 1; 0 0 -3])
+
+    vis = Visualizer(poly2)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,10 @@ using Meshing
 using Base.Test
 using IJulia
 import Iterators: product
+using Polyhedra
+using CDDLib
 
 include("lazytree.jl")
 include("comms_t.jl")
 include("visualizer.jl")
+include("polyhedra.jl")


### PR DESCRIPTION
Attempt to fix rendering of custom geometries (like Polyhedra)


Also, the two-way communication between the viewer and client is causing more trouble than benefit right now. I need to think harder about what it should actually be doing. 

