### PR TITLE
support mesh files and improve PointCloud constructor

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,6 +4,8 @@ BinDeps 0.4.0
 GeometryTypes 0.4
 ColorTypes 0.2.0
 Meshing 0.2.0
+MeshIO 0.1
+FileIO 0.2.2
 Rotations 0.5.0
 CoordinateTransformations 0.2.0
 StaticArrays 0.5

--- a/src/DrakeVisualizer.jl
+++ b/src/DrakeVisualizer.jl
@@ -4,8 +4,10 @@ module DrakeVisualizer
 
 using LCMCore
 using GeometryTypes
+using FileIO
 import GeometryTypes: origin, radius, raw
 import Meshing
+import MeshIO
 import Rotations: Rotation, Quat
 import CoordinateTransformations: Transformation,
                                   transform_deriv,
@@ -29,6 +31,7 @@ export GeometryData,
         HyperCylinder,
         HyperSphere,
         HyperCube,
+        MeshFile,
         PointCloud,
         Point,
         Vec,

--- a/src/geometry_types.jl
+++ b/src/geometry_types.jl
@@ -29,11 +29,15 @@ struct PointCloud{T, Point <: StaticArray{Tuple{3}, T}} <: AbstractGeometry{3, T
     channels::Dict{Symbol, Any}
 end
 
-PointCloud(points::AbstractVector{Point}) where {T, Point <: StaticArray{Tuple{3}, T}} =
-    PointCloud{T, Point}(points, Dict{Symbol, Any}())
+function PointCloud(points::AbstractVector{Point}, 
+                    channels::Dict=Dict{Symbol, Any}()) where {T, Point <: StaticArray{Tuple{3}, T}}
+    PointCloud{T, Point}(points, channels)
+end
 
-PointCloud(points::AbstractVector{V}) where {T, V <: AbstractVector{T}} =
-    PointCloud{T, Point{3, T}}(points, Dict{Symbol, Any}())
+function PointCloud(points::AbstractVector{V},
+                    channels::Dict=Dict{Symbol, Any}()) where {T, V <: AbstractVector{T}}
+    PointCloud{T, Point{3, T}}(points, channels)
+end
 
 struct Triad <: AbstractGeometry{3, Float64}
     scale::Float64
@@ -71,4 +75,21 @@ function PolyLine(points::AbstractVector{V};
     PolyLine(points, radius, closed,
              start_head,
              end_head)
+end
+
+"""
+A MeshFile is a wrapper around a mesh that indicates that the mesh should be
+transmitted to the viewer by saving its data to a file and sending that file's
+path to the viewer. This can avoid issues with very large meshes (which cannot
+otherwise be sent over LCM), but will not work if the viewer is not running
+locally.
+"""
+struct MeshFile <: AbstractGeometry{3, Float64}
+    filename::String
+end
+
+function MeshFile(mesh::AbstractMesh)
+    path = string(tempname(), ".ply")
+    save(path, mesh)
+    MeshFile(path)
 end

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -87,6 +87,12 @@ function serialize(g::AbstractMesh)
          "faces" => serialize.(faces(g)))
 end
 
+function serialize(f::MeshFile)
+    Dict("type" => "mesh_file",
+         "filename" => f.filename,
+         "scale" => SVector(1.0, 1.0, 1.0))
+end
+
 function serialize(g::PointCloud)
     params = Dict("type" => "pointcloud",
                   "points" => serialize.(g.points),

--- a/test/visualizer.jl
+++ b/test/visualizer.jl
@@ -1,3 +1,5 @@
+using ColorTypes: RGB
+
 proc = DrakeVisualizer.new_window()
 
 @testset "open window" begin
@@ -74,6 +76,32 @@ end
                                               start_head=ArrowHead()))
 
     setgeometry!(vis[:basic_line], PolyLine([[0., 0, 0], [1., 0, 0]]))
+end
+
+@testset "pointcloud" begin
+    vis = Visualizer()
+    setgeometry!(vis[:pointcloud1],
+                 PointCloud([[0., 0, 0], [1., 0, 0]]))
+    setgeometry!(vis[:pointcloud2],
+                 PointCloud([Point(0., 0.5, 0), Point(1., 0.5, 0)]))
+    setgeometry!(vis[:pointcloud2_rgb],
+                 PointCloud([Point(0., 1., 0), Point(1., 1., 0)],
+                            Dict(:rgb=>[RGB(1., 1., 0.), RGB(1., 0., 1.)])))
+end
+
+@testset "mesh files" begin
+    vis = Visualizer()
+
+    @testset "existing mesh" begin
+        setgeometry!(vis[:mesh_file_existing], MeshFile(joinpath(Pkg.dir("GeometryTypes"), "test", "data", "cat.obj")))
+    end
+
+    @testset "new mesh" begin
+        f = x -> norm(x)^2
+        iso_level = 0.5
+        mesh = contour_mesh(f, [0.,0,0], [1.,1,1], iso_level)
+        setgeometry!(vis[:mesh_file], MeshFile(mesh))
+    end
 end
 
 


### PR DESCRIPTION
New MeshFile type indicates that a mesh should be visualized by sending its file path to the viewer, rather than its data. 