### PR TITLE
Fix deprecations and clean up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ before_script:
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia -e 'Pkg.clone(pwd()); Pkg.build("DrakeVisualizer")'
+  - julia -e 'Pkg.checkout("LCMCore"); Pkg.build("LCMCore")'
   # use xvfb on Linux:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then xvfb-run -a -s "-screen 0 1024x768x24" -e /dev/stdout julia -e 'Pkg.test("DrakeVisualizer"; coverage=true)'; fi
   # just run regularly on OSX:

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,6 @@ before_script:
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia -e 'Pkg.clone(pwd()); Pkg.build("DrakeVisualizer")'
-  - julia -e 'Pkg.checkout("LCMCore"); Pkg.build("LCMCore")'
   # use xvfb on Linux:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then xvfb-run -a -s "-screen 0 1024x768x24" -e /dev/stdout julia -e 'Pkg.test("DrakeVisualizer"; coverage=true)'; fi
   # just run regularly on OSX:

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,7 +3,7 @@ LCMCore 0.1.0
 BinDeps 0.4.0
 GeometryTypes 0.4
 ColorTypes 0.2.0
-Meshing 0.2.0
+Meshing 0.3.1
 MeshIO 0.1
 FileIO 0.2.2
 Rotations 0.5.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
-LCMCore 0.1.0
+LCMCore 0.2.0
 BinDeps 0.4.0
 GeometryTypes 0.4
 ColorTypes 0.2.0

--- a/src/DrakeVisualizer.jl
+++ b/src/DrakeVisualizer.jl
@@ -6,7 +6,7 @@ using LCMCore
 using GeometryTypes
 using FileIO
 import GeometryTypes: origin, radius, raw
-import Meshing
+import Meshing: MarchingTetrahedra
 import MeshIO
 import Rotations: Rotation, Quat
 import CoordinateTransformations: Transformation,
@@ -108,8 +108,5 @@ include("contour_meshes.jl")
 include("geometry_types.jl")
 include("visualizer.jl")
 include("serialization.jl")
-
-@deprecate load!(args...) setgeometry!(args...)
-@deprecate draw!(args...) settransform!(args...)
 
 end

--- a/src/lcmtypes/comms_t.jl
+++ b/src/lcmtypes/comms_t.jl
@@ -1,7 +1,6 @@
 module Comms
 
 using LCMCore
-using StaticArrays
 
 mutable struct CommsT <: LCMType
     utime::Int64
@@ -16,9 +15,8 @@ function CommsT(utime::Integer, format::String, format_version_major::Integer, f
     CommsT(utime, format, format_version_major, format_version_minor, length(data), data)
 end
 
-LCMCore.fingerprint(::Type{CommsT}) = SVector(0xd3, 0x68, 0xe0, 0x3f, 0x33, 0xc5, 0x68, 0xbe)
-LCMCore.size_fields(::Type{CommsT}) = (:num_bytes,)
-LCMCore.check_valid(x::CommsT) = @assert length(x.data) == x.num_bytes
-Base.resize!(x::CommsT) = resize!(x.data, x.num_bytes)
+@lcmtypesetup(CommsT, 
+    (data, 1) => num_bytes
+)
 
 end

--- a/src/lcmtypes/comms_t.jl
+++ b/src/lcmtypes/comms_t.jl
@@ -15,8 +15,8 @@ function CommsT(utime::Integer, format::String, format_version_major::Integer, f
     CommsT(utime, format, format_version_major, format_version_minor, length(data), data)
 end
 
-@lcmtypesetup(CommsT, 
-    (data, 1) => num_bytes
+@lcmtypesetup(CommsT,
+    data => (num_bytes, )
 )
 
 end

--- a/src/lcmtypes/comms_t.jl
+++ b/src/lcmtypes/comms_t.jl
@@ -11,12 +11,12 @@ mutable struct CommsT <: LCMType
     data::Vector{UInt8}
 end
 
-function CommsT(utime::Integer, format::String, format_version_major::Integer, format_version_minor::Integer, data::Vector{UInt8})
-    CommsT(utime, format, format_version_major, format_version_minor, length(data), data)
-end
-
 @lcmtypesetup(CommsT,
     data => (num_bytes, )
 )
+
+function CommsT(utime::Integer, format::String, format_version_major::Integer, format_version_minor::Integer, data::Vector{UInt8})
+    CommsT(utime, format, format_version_major, format_version_minor, length(data), data)
+end
 
 end

--- a/test/visualizer.jl
+++ b/test/visualizer.jl
@@ -110,12 +110,6 @@ end
     delete!(vis)
 end
 
-@testset "deprecations" begin
-    vis = Visualizer()
-    load!(vis, HyperCylinder{3, Float64}(1.0, 2.0))
-    draw!(vis, IdentityTransformation())
-end
-
 @testset "addgeometry" begin
     vis = Visualizer()
     delete!(vis)


### PR DESCRIPTION
Updates to use the new `@lcmtypesetup` macro from LCMCore.jl (cc @tkoolen)

Also removes the ancient and long-deprecated `load!()` and `draw!()` methods and updates to the latest and greatest Meshing.jl. 