### PR TITLE
Retire DrakeVisualizer.jl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.jl.*.cov
 *.jl.mem
 *.pyc
+*.log
+.ipynb_checkpoints

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,16 @@ matrix:
   include:
     - os: linux
       julia: 0.7
-      env: TESTCMD="xvfb-run julia"
+      env: TESTCMD="xvfb-run -a -s \"-screen 0 1024x768x24\" -e /dev/stdout julia"
     - os: linux
       julia: 1.0
-      env: TESTCMD="xvfb-run julia"
+      env: TESTCMD="xvfb-run -a -s \"-screen 0 1024x768x24\" -e /dev/stdout julia"
     - os: linux
       julia: 1.1
-      env: TESTCMD="xvfb-run julia"
+      env: TESTCMD="xvfb-run -a -s \"-screen 0 1024x768x24\" -e /dev/stdout julia"
     - os: linux
       julia: 1.1
-      env: DIRECTOR_BUILD_FROM_SOURCE=1 TESTCMD="xvfb-run julia"
+      env: DIRECTOR_BUILD_FROM_SOURCE=1 TESTCMD="xvfb-run -a -s \"-screen 0 1024x768x24\" -e /dev/stdout julia"
     - os: osx
       julia: 0.7
       env: TESTCMD="julia"
@@ -38,9 +38,9 @@ addons:
       - python-numpy
       - python-scipy
       - python-yaml
-      - mesa-utils
-      - libgl1-mesa-glx
-      - libgl1-mesa-dev
+      # - mesa-utils
+      # - libgl1-mesa-glx
+      # - libgl1-mesa-dev
 
 before_script:
   # https://lcm-proj.github.io/multicast_setup.html:
@@ -48,6 +48,9 @@ before_script:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo sysctl -w net.core.rmem_max=2097152; fi
   # OSX deps:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then pip2 install numpy scipy lxml PyYAML; fi
+    # X virtual frame buffer:
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16; fi
+  - sleep 3
 
 script:
   - julia --color=yes -e "using Pkg; if VERSION >= v\"1.1.0-rc1\"; Pkg.build(verbose=true); else Pkg.build(); end"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,10 @@ matrix:
       env: DIRECTOR_BUILD_FROM_SOURCE=1 TESTCMD="xvfb-run julia"
     - os: osx
       julia: 0.7
+      env: TESTCMD="julia"
     - os: osx
       julia: 1.1
+      env: TESTCMD="julia"
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ addons:
       - python-numpy
       - python-scipy
       - python-yaml
+      - mesa-utils
+      - libgl1-mesa-glx
 
 before_script:
   # https://lcm-proj.github.io/multicast_setup.html:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ matrix:
       env: TESTCMD="xvfb-run julia"
     - os: linux
       julia: 1.1
-      env: DIRECTOR_BUILD_FROM_SOURCE=1
-      env: TESTCMD="xvfb-run julia"
+      env: DIRECTOR_BUILD_FROM_SOURCE=1 TESTCMD="xvfb-run julia"
     - os: osx
       julia: 0.7
     - os: osx
@@ -44,9 +43,6 @@ before_script:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo sysctl -w net.core.rmem_max=2097152; fi
   # OSX deps:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then pip2 install numpy scipy lxml PyYAML; fi
-  # X virtual frame buffer:
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16; fi
-  - sleep 3
 
 script:
   - julia --color=yes -e "using Pkg; if VERSION >= v\"1.1.0-rc1\"; Pkg.build(verbose=true); else Pkg.build(); end"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,21 @@ matrix:
   include:
     - os: linux
       julia: 0.7
+      env: TESTCMD="xvfb-run julia"
     - os: linux
       julia: 1.0
+      env: TESTCMD="xvfb-run julia"
     - os: linux
-      julia: nightly
+    - julia: 1.1
+      env: TESTCMD="xvfb-run julia"
     - os: linux
-      julia: 1.0
+      julia: 1.1
       env: DIRECTOR_BUILD_FROM_SOURCE=1
+      env: TESTCMD="xvfb-run julia"
     - os: osx
       julia: 0.7
     - os: osx
-      julia: 1.0
-
-  allow_failures:
-    - julia: nightly
+      julia: 1.1
 
 addons:
   apt:
@@ -50,16 +51,12 @@ before_script:
   - sleep 3
 
 script:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("DrakeVisualizer")'
-  # use xvfb on Linux:
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then xvfb-run -a -s "-screen 0 1024x768x24" -e /dev/stdout julia -e 'using Pkg; Pkg.test("DrakeVisualizer"; coverage=true)'; fi
-  # just run regularly on OSX:
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then julia -e 'using Pkg; Pkg.test("DrakeVisualizer"; coverage=true)'; fi
+  - julia --color=yes -e "using Pkg; if VERSION >= v\"1.1.0-rc1\"; Pkg.build(verbose=true); else Pkg.build(); end"
+  - $TESTCMD --check-bounds=yes --color=yes -e 'using Pkg; Pkg.test("MeshCat", coverage=true)'
 
 notifications:
   email: false
 branches:
   only: master
 after_success:
-  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+  - julia -e 'import Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ addons:
       - python-yaml
       - mesa-utils
       - libgl1-mesa-glx
+      - libgl1-mesa-dev
 
 before_script:
   # https://lcm-proj.github.io/multicast_setup.html:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,6 @@ addons:
       - python-numpy
       - python-scipy
       - python-yaml
-      # - mesa-utils
-      # - libgl1-mesa-glx
-      # - libgl1-mesa-dev
 
 before_script:
   # https://lcm-proj.github.io/multicast_setup.html:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
       julia: 1.0
       env: TESTCMD="xvfb-run julia"
     - os: linux
-    - julia: 1.1
+      julia: 1.1
       env: TESTCMD="xvfb-run julia"
     - os: linux
       julia: 1.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ before_script:
 
 script:
   - julia --color=yes -e "using Pkg; if VERSION >= v\"1.1.0-rc1\"; Pkg.build(verbose=true); else Pkg.build(); end"
-  - $TESTCMD --check-bounds=yes --color=yes -e 'using Pkg; Pkg.test("MeshCat", coverage=true)'
+  - $TESTCMD --check-bounds=yes --color=yes -e 'using Pkg; Pkg.test("DrakeVisualizer", coverage=true)'
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 # Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
-dist: trusty
-sudo: required
 
 matrix:
   include:
@@ -26,19 +24,19 @@ matrix:
 addons:
   apt:
     packages:
-    # https://stackoverflow.com/a/34549360
-    - xorg
-    - xvfb
-    - dbus-x11
-    - xfonts-100dpi
-    - xfonts-75dpi
-    - xfonts-cyrillic
-    # director python deps:
-    - python-dev
-    - python-lxml
-    - python-numpy
-    - python-scipy
-    - python-yaml
+      # https://stackoverflow.com/a/34549360
+      - xorg
+      - xvfb
+      - dbus-x11
+      - xfonts-100dpi
+      - xfonts-75dpi
+      - xfonts-cyrillic
+      # director python deps:
+      - python-dev
+      - python-lxml
+      - python-numpy
+      - python-scipy
+      - python-yaml
 
 before_script:
   # https://lcm-proj.github.io/multicast_setup.html:

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,223 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[BinDeps]]
+deps = ["Compat", "Libdl", "SHA", "URIParser"]
+git-tree-sha1 = "12093ca6cdd0ee547c39b1870e0c9c3f154d9ca9"
+uuid = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
+version = "0.8.10"
+
+[[CMake]]
+deps = ["BinDeps", "Libdl", "Test"]
+git-tree-sha1 = "6e39bef3cbb8321e8a464b18a5c20d7cef813938"
+uuid = "631607c0-34d2-5d66-819e-eb0f9aa2061a"
+version = "1.1.1"
+
+[[CMakeWrapper]]
+deps = ["BinDeps", "CMake", "Libdl", "Parameters", "Test"]
+git-tree-sha1 = "2b43d451639984e3571951cc687b8509b0a86c6d"
+uuid = "d5fb7624-851a-54ee-a528-d3f3bac0b4a0"
+version = "0.2.2"
+
+[[ColorTypes]]
+deps = ["FixedPointNumbers", "Random", "Test"]
+git-tree-sha1 = "f73b0e10f2a5756de7019818a41654686da06b09"
+uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+version = "0.7.5"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "49269e311ffe11ac5b334681d212329002a9832a"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "1.5.1"
+
+[[CoordinateTransformations]]
+deps = ["Compat", "Rotations", "StaticArrays"]
+git-tree-sha1 = "47f05d0b7f4999609f92e657147df000818c1f24"
+uuid = "150eb455-5306-5404-9cee-2592286d6298"
+version = "0.5.0"
+
+[[DataStructures]]
+deps = ["InteractiveUtils", "OrderedCollections", "Random", "Serialization", "Test"]
+git-tree-sha1 = "ca971f03e146cf144a9e2f2ce59674f5bf0e8038"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.15.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[FastIOBuffers]]
+deps = ["Compat"]
+git-tree-sha1 = "c150c7f2a83d8621bdaaf98756f23d594d907077"
+uuid = "6ccb8d0d-f5f8-5ae0-a392-f5aa62729a81"
+version = "0.2.0"
+
+[[FileIO]]
+deps = ["Pkg", "Random", "Test"]
+git-tree-sha1 = "c94b0787956629036fb2b20fccde9e52b89d079a"
+uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+version = "1.0.5"
+
+[[FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+
+[[FixedPointNumbers]]
+deps = ["Test"]
+git-tree-sha1 = "b8045033701c3b10bf2324d7203404be7aef88ba"
+uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
+version = "0.5.3"
+
+[[GeometryTypes]]
+deps = ["ColorTypes", "FixedPointNumbers", "IterTools", "LinearAlgebra", "StaticArrays", "Test"]
+git-tree-sha1 = "28b193e14466beecf928449e0f8505ff6de3709d"
+uuid = "4d00f742-c7ba-57c2-abde-4428a4b178cb"
+version = "0.7.2"
+
+[[Homebrew]]
+deps = ["BinDeps", "InteractiveUtils", "JSON", "Libdl", "Test", "Unicode"]
+git-tree-sha1 = "f01fb2f34675f9839d55ba7238bab63ebd2e531e"
+uuid = "d9be37ee-ecc9-5288-90f1-b9ca67657a75"
+version = "0.7.1"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[IterTools]]
+deps = ["SparseArrays", "Test"]
+git-tree-sha1 = "79246285c43602384e6f1943b3554042a3712056"
+uuid = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
+version = "1.1.1"
+
+[[JSON]]
+deps = ["Dates", "Distributed", "Mmap", "Sockets", "Test", "Unicode"]
+git-tree-sha1 = "1f7a25b53ec67f5e9422f1f551ee216503f4a0fa"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.20.0"
+
+[[LCMCore]]
+deps = ["BinDeps", "CMakeWrapper", "Dates", "FastIOBuffers", "FileWatching", "Homebrew", "Libdl", "Pkg", "Random", "StaticArrays", "Test", "UnsafeArrays"]
+git-tree-sha1 = "9859335c6d09e6aa1ddfcd5fcac365b7600bc9fc"
+uuid = "0ea44823-1ff1-5b9a-8293-5fd55a38e746"
+version = "0.5.4"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[MeshIO]]
+deps = ["ColorTypes", "FileIO", "GeometryTypes", "Printf", "Test"]
+git-tree-sha1 = "3e01e12c4c626578a9d47fac0d15c9fe8dad5139"
+uuid = "7269a6da-0436-5bbc-96c2-40638cbb6118"
+version = "0.3.1"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[OrderedCollections]]
+deps = ["Random", "Serialization", "Test"]
+git-tree-sha1 = "85619a3f3e17bb4761fe1b1fd47f0e979f964d5b"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.0.2"
+
+[[Parameters]]
+deps = ["Markdown", "OrderedCollections", "REPL", "Test"]
+git-tree-sha1 = "70bdbfb2bceabb15345c0b54be4544813b3444e4"
+uuid = "d96e819e-fc66-5662-9728-84c9c7592b0a"
+version = "0.10.3"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Rotations]]
+deps = ["LinearAlgebra", "Random", "StaticArrays", "Statistics", "Test"]
+git-tree-sha1 = "dfb3ceb177a59f25fee4e2f26c1aeb92b73d3a0e"
+uuid = "6038ab10-8711-5258-84ad-4b1120ba62dc"
+version = "0.11.1"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[StaticArrays]]
+deps = ["InteractiveUtils", "LinearAlgebra", "Random", "Statistics", "Test"]
+git-tree-sha1 = "3841b39ed5f047db1162627bf5f80a9cd3e39ae2"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "0.10.3"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[URIParser]]
+deps = ["Test", "Unicode"]
+git-tree-sha1 = "6ddf8244220dfda2f17539fa8c9de20d6c575b69"
+uuid = "30578b45-9adc-5946-b283-645ec420af67"
+version = "0.4.0"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[UnsafeArrays]]
+deps = ["Compat"]
+git-tree-sha1 = "460f4f7bab69dd47512ac8ec4b2c14b28c6cb4a0"
+uuid = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
+version = "0.3.0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,33 @@
+name = "DrakeVisualizer"
+uuid = "49c7015b-b8db-5bc5-841b-fcb31c578176"
+authors = ["Robin Deits <robin.deits@gmail.com>"]
+version = "0.4.0"
+
+[deps]
+BinDeps = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
+CMakeWrapper = "d5fb7624-851a-54ee-a528-d3f3bac0b4a0"
+ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+GeometryTypes = "4d00f742-c7ba-57c2-abde-4428a4b178cb"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+LCMCore = "0ea44823-1ff1-5b9a-8293-5fd55a38e746"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MeshIO = "7269a6da-0436-5bbc-96c2-40638cbb6118"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[compat]
+julia = "0.7, 1.0"
+
+[extras]
+Meshing = "e6723b4c-ebff-59f1-b4b7-d97aa5274f73"
+NBInclude = "0db19996-df87-5ea3-a455-e3a50d440464"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test", "Meshing", "NBInclude", "Pkg"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@
 
 ---
 
-**Note:** While this package should still work, active development has been moved to [MeshCat.jl](https://github.com/rdeits/MeshCat.jl), which offers more features and a much less complicated set of dependencies.
+## Status: Retired
+
+This package is no longer under active maintenance, as of March 2019. Everything here should continue to work with all current and future Julia 1.x versions, but there is no further work planned on this package.
+
+Instead, active development has moved to [MeshCat.jl](https://github.com/rdeits/MeshCat.jl), which offers a similar API but with more features, better performance, and fewer binary dependencies.
 
 ---
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,11 +1,8 @@
 julia 0.7
-LCMCore 0.2.0
+LCMCore 0.5.1
 BinDeps 0.4.0
 GeometryTypes 0.4
 ColorTypes 0.2.0
-Meshing 0.3.1
-MeshIO 0.1
-FileIO 0.2.2
 Rotations 0.5.0
 CoordinateTransformations 0.2.0
 StaticArrays 0.5

--- a/notebooks/Manifest.toml
+++ b/notebooks/Manifest.toml
@@ -1,0 +1,239 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[BinDeps]]
+deps = ["Compat", "Libdl", "SHA", "URIParser"]
+git-tree-sha1 = "12093ca6cdd0ee547c39b1870e0c9c3f154d9ca9"
+uuid = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
+version = "0.8.10"
+
+[[CMake]]
+deps = ["BinDeps", "Libdl", "Test"]
+git-tree-sha1 = "6e39bef3cbb8321e8a464b18a5c20d7cef813938"
+uuid = "631607c0-34d2-5d66-819e-eb0f9aa2061a"
+version = "1.1.1"
+
+[[CMakeWrapper]]
+deps = ["BinDeps", "CMake", "Libdl", "Parameters", "Test"]
+git-tree-sha1 = "2b43d451639984e3571951cc687b8509b0a86c6d"
+uuid = "d5fb7624-851a-54ee-a528-d3f3bac0b4a0"
+version = "0.2.2"
+
+[[ColorTypes]]
+deps = ["FixedPointNumbers", "Random", "Test"]
+git-tree-sha1 = "f73b0e10f2a5756de7019818a41654686da06b09"
+uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+version = "0.7.5"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "49269e311ffe11ac5b334681d212329002a9832a"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "1.5.1"
+
+[[CoordinateTransformations]]
+deps = ["Compat", "Rotations", "StaticArrays"]
+git-tree-sha1 = "47f05d0b7f4999609f92e657147df000818c1f24"
+uuid = "150eb455-5306-5404-9cee-2592286d6298"
+version = "0.5.0"
+
+[[DataStructures]]
+deps = ["InteractiveUtils", "OrderedCollections", "Random", "Serialization", "Test"]
+git-tree-sha1 = "ca971f03e146cf144a9e2f2ce59674f5bf0e8038"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.15.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[DrakeVisualizer]]
+deps = ["BinDeps", "CMakeWrapper", "ColorTypes", "CoordinateTransformations", "DataStructures", "GeometryTypes", "JSON", "LCMCore", "Rotations", "StaticArrays"]
+path = ".."
+uuid = "49c7015b-b8db-5bc5-841b-fcb31c578176"
+version = "0.4.0"
+
+[[FastIOBuffers]]
+deps = ["Compat"]
+git-tree-sha1 = "c150c7f2a83d8621bdaaf98756f23d594d907077"
+uuid = "6ccb8d0d-f5f8-5ae0-a392-f5aa62729a81"
+version = "0.2.0"
+
+[[FileIO]]
+deps = ["Pkg", "Random", "Test"]
+git-tree-sha1 = "c94b0787956629036fb2b20fccde9e52b89d079a"
+uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+version = "1.0.5"
+
+[[FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+
+[[FixedPointNumbers]]
+deps = ["Test"]
+git-tree-sha1 = "b8045033701c3b10bf2324d7203404be7aef88ba"
+uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
+version = "0.5.3"
+
+[[GeometryTypes]]
+deps = ["ColorTypes", "FixedPointNumbers", "IterTools", "LinearAlgebra", "StaticArrays", "Test"]
+git-tree-sha1 = "28b193e14466beecf928449e0f8505ff6de3709d"
+uuid = "4d00f742-c7ba-57c2-abde-4428a4b178cb"
+version = "0.7.2"
+
+[[Homebrew]]
+deps = ["BinDeps", "InteractiveUtils", "JSON", "Libdl", "Test", "Unicode"]
+git-tree-sha1 = "f01fb2f34675f9839d55ba7238bab63ebd2e531e"
+uuid = "d9be37ee-ecc9-5288-90f1-b9ca67657a75"
+version = "0.7.1"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[IterTools]]
+deps = ["SparseArrays", "Test"]
+git-tree-sha1 = "79246285c43602384e6f1943b3554042a3712056"
+uuid = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
+version = "1.1.1"
+
+[[JSON]]
+deps = ["Dates", "Distributed", "Mmap", "Sockets", "Test", "Unicode"]
+git-tree-sha1 = "1f7a25b53ec67f5e9422f1f551ee216503f4a0fa"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.20.0"
+
+[[LCMCore]]
+deps = ["BinDeps", "CMakeWrapper", "Dates", "FastIOBuffers", "FileWatching", "Homebrew", "Libdl", "Pkg", "Random", "StaticArrays", "Test", "UnsafeArrays"]
+git-tree-sha1 = "9859335c6d09e6aa1ddfcd5fcac365b7600bc9fc"
+uuid = "0ea44823-1ff1-5b9a-8293-5fd55a38e746"
+version = "0.5.4"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[MeshIO]]
+deps = ["ColorTypes", "FileIO", "GeometryTypes", "Printf", "Test"]
+git-tree-sha1 = "3e01e12c4c626578a9d47fac0d15c9fe8dad5139"
+uuid = "7269a6da-0436-5bbc-96c2-40638cbb6118"
+version = "0.3.1"
+
+[[Meshing]]
+deps = ["GeometryTypes", "LinearAlgebra", "Profile", "Statistics", "Test"]
+git-tree-sha1 = "98269f9374384fa082aede132ea8195c3d9fba4e"
+uuid = "e6723b4c-ebff-59f1-b4b7-d97aa5274f73"
+version = "0.4.0"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[OrderedCollections]]
+deps = ["Random", "Serialization", "Test"]
+git-tree-sha1 = "85619a3f3e17bb4761fe1b1fd47f0e979f964d5b"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.0.2"
+
+[[Parameters]]
+deps = ["Markdown", "OrderedCollections", "REPL", "Test"]
+git-tree-sha1 = "70bdbfb2bceabb15345c0b54be4544813b3444e4"
+uuid = "d96e819e-fc66-5662-9728-84c9c7592b0a"
+version = "0.10.3"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[Profile]]
+deps = ["Printf"]
+uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Rotations]]
+deps = ["LinearAlgebra", "Random", "StaticArrays", "Statistics", "Test"]
+git-tree-sha1 = "dfb3ceb177a59f25fee4e2f26c1aeb92b73d3a0e"
+uuid = "6038ab10-8711-5258-84ad-4b1120ba62dc"
+version = "0.11.1"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[StaticArrays]]
+deps = ["InteractiveUtils", "LinearAlgebra", "Random", "Statistics", "Test"]
+git-tree-sha1 = "3841b39ed5f047db1162627bf5f80a9cd3e39ae2"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "0.10.3"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[URIParser]]
+deps = ["Test", "Unicode"]
+git-tree-sha1 = "6ddf8244220dfda2f17539fa8c9de20d6c575b69"
+uuid = "30578b45-9adc-5946-b283-645ec420af67"
+version = "0.4.0"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[UnsafeArrays]]
+deps = ["Compat"]
+git-tree-sha1 = "460f4f7bab69dd47512ac8ec4b2c14b28c6cb4a0"
+uuid = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
+version = "0.3.0"

--- a/notebooks/Project.toml
+++ b/notebooks/Project.toml
@@ -1,0 +1,8 @@
+[deps]
+ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
+DrakeVisualizer = "49c7015b-b8db-5bc5-841b-fcb31c578176"
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+GeometryTypes = "4d00f742-c7ba-57c2-abde-4428a4b178cb"
+MeshIO = "7269a6da-0436-5bbc-96c2-40638cbb6118"
+Meshing = "e6723b4c-ebff-59f1-b4b7-d97aa5274f73"

--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -16,12 +16,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Optional: \n",
+    "# These commands tell the Julia package manager to use the exact\n",
+    "# set of dependencies specified in the Project.toml and\n",
+    "# Manifest.toml files in this folder. That should\n",
+    "# give you a nice, reproducible environment for testing. \n",
+    "\n",
+    "using Pkg\n",
+    "Pkg.activate(@__DIR__)\n",
+    "Pkg.instantiate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Activate the DrakeVisualizer package, and import some other \n",
     "# useful functions\n",
     "using DrakeVisualizer\n",
     "using CoordinateTransformations\n",
-    "using Interact\n",
-    "using GeometryTypes: HyperRectangle, Vec, HomogenousMesh\n",
+    "using GeometryTypes: GeometryTypes, HyperRectangle, Vec, HomogenousMesh\n",
     "using ColorTypes: RGBA"
    ]
   },
@@ -263,25 +279,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's try interactively moving the entire group (with the first slider) and also just the green box (with the second slider):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "@manipulate for x1 in 0:0.01:2, x2 in 0:0.01:2\n",
-    "    settransform!(vis[:group1], Translation(x1, 0, 0))\n",
-    "    settransform!(vis[:group1][:greenbox], Translation(x2, 1, 0))\n",
-    "end"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Likewise, we can delete an entire group:"
    ]
   },
@@ -304,7 +301,6 @@
     "# just simple boxes. Let's load a 3D mesh and visualize it:\n",
     "using MeshIO\n",
     "using FileIO\n",
-    "import GeometryTypes\n",
     "cat_mesh = load(joinpath(dirname(pathof(GeometryTypes)), \"..\", \"test\", \"data\", \"cat.obj\"))\n",
     "\n",
     "model = Visualizer(cat_mesh);\n",
@@ -346,30 +342,6 @@
     "\n",
     "# And now we can load that geometry into the visualizer\n",
     "model = Visualizer(mesh)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# We can even manipulate the geometry by changing the iso level. \n",
-    "# By default, contour_mesh constructs a mesh connecting the points \n",
-    "# in space for which f(x) = 0, where 0 is called the isosurface level\n",
-    "# or iso level. But we can change that iso level to any number we want:\n",
-    "\n",
-    "# Note that for high iso_level values our geometry gets cut off at the\n",
-    "# edges. We could fix that by replacing the bounds with a bigger box. \n",
-    "\n",
-    "f = x -> sum(sin, 5 * x)\n",
-    "lower_bound = Vec(-1.,-1,-1)\n",
-    "upper_bound = Vec(1., 1, 1)\n",
-    "\n",
-    "@manipulate for iso_level in -1:0.01:1\n",
-    "    geometry = contour_mesh(f, lower_bound, upper_bound, iso_level)\n",
-    "    model = Visualizer(geometry)\n",
-    "end"
    ]
   },
   {
@@ -508,16 +480,20 @@
   }
  ],
  "metadata": {
+  "@webio": {
+   "lastCommId": "802dbde996f140c4850191e992e4fd34",
+   "lastKernelId": "cf699830-d365-4dc7-84b5-6f35f7abf242"
+  },
   "kernelspec": {
-   "display_name": "Julia 0.7.0",
+   "display_name": "Julia 1.1.0",
    "language": "julia",
-   "name": "julia-0.7"
+   "name": "julia-1.1"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "0.7.0"
+   "version": "1.1.0"
   }
  },
  "nbformat": 4,

--- a/src/DrakeVisualizer.jl
+++ b/src/DrakeVisualizer.jl
@@ -2,10 +2,10 @@ module DrakeVisualizer
 
 using LCMCore
 using GeometryTypes
-using FileIO
 using LinearAlgebra
-
 import MeshIO
+using FileIO: load, save
+
 import JSON
 
 using Meshing: MarchingTetrahedra

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,5 +1,2 @@
-Iterators 0.2
 NBInclude 1.1.0
-Interact 0.4
 MeshIO 0.1.0
-Reactive 0.3

--- a/test/notebook.jl
+++ b/test/notebook.jl
@@ -1,5 +1,5 @@
 using NBInclude
 
 @testset "notebook" begin
-    @nbinclude(joinpath(@__DIR__, "..", "demo.ipynb"))
+    @nbinclude(joinpath(@__DIR__, "..", "notebooks", "demo.ipynb"))
 end

--- a/test/visualizer.jl
+++ b/test/visualizer.jl
@@ -120,7 +120,7 @@ end
     addgeometry!(vis[:box1], HyperSphere(Point(0., 0, 0), 1.0))
 end
 
-if haskey(ENV, "DISPLAY") && (get(ENV, "TRAVIS", "false") == "false" || ENV["TRAVIS_OS_NAME"] == "linux")
+if haskey(ENV, "DISPLAY") && (get(ENV, "TRAVIS", "false") == "false")
     @testset "script" begin
         expected_file = joinpath(@__DIR__, "test_script_success")
         isfile(expected_file) && rm(expected_file)


### PR DESCRIPTION
I think it's time for DrakeVisualizer.jl to retire. I haven't used it in years, and I don't think anyone else has either.

To make sure it has a happy retirement, I've gone and created Project and Manifest files for the package itself and for its demo notebook. That should ensure that they remain usable forever, even if the package isn't getting any new features. 

@tkoolen any objections to putting this package out to pasture? 